### PR TITLE
feat: Input 컴포넌트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.10.0",
     "axios": "^1.7.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.54.2",
     "react-router-dom": "^7.1.1",
     "react-spinners": "^0.15.0",
-    "styled-components": "^6.1.14"
+    "styled-components": "^6.1.14",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^3.10.0
+        version: 3.10.0(react-hook-form@7.54.2(react@18.3.1))
       axios:
         specifier: ^1.7.9
         version: 1.7.9
@@ -17,6 +20,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.54.2
+        version: 7.54.2(react@18.3.1)
       react-router-dom:
         specifier: ^7.1.1
         version: 7.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -26,6 +32,9 @@ importers:
       styled-components:
         specifier: ^6.1.14
         version: 6.1.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.17.0
@@ -359,6 +368,11 @@ packages:
   '@eslint/plugin-kit@0.2.5':
     resolution: {integrity: sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@hookform/resolvers@3.10.0':
+    resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1383,6 +1397,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-hook-form@7.54.2:
+    resolution: {integrity: sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -1678,6 +1698,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
+
 snapshots:
 
   '@ampproject/remapping@2.3.0':
@@ -1919,6 +1942,10 @@ snapshots:
     dependencies:
       '@eslint/core': 0.10.0
       levn: 0.4.1
+
+  '@hookform/resolvers@3.10.0(react-hook-form@7.54.2(react@18.3.1))':
+    dependencies:
+      react-hook-form: 7.54.2(react@18.3.1)
 
   '@humanfs/core@0.19.1': {}
 
@@ -3056,6 +3083,10 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-hook-form@7.54.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   react-is@16.13.1: {}
 
   react-refresh@0.14.2: {}
@@ -3436,3 +3467,5 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.24.1: {}

--- a/src/components/views/inputGroup/Input.jsx
+++ b/src/components/views/inputGroup/Input.jsx
@@ -1,0 +1,65 @@
+import { useContext } from 'react'
+import { useFormContext } from 'react-hook-form'
+import styled from 'styled-components'
+
+import { InputGroupContext } from '@/hooks/useInputGroupContext'
+import { font } from '@/styles/font'
+import { colors } from '@/styles/palette'
+
+export const Input = (props) => {
+  const { register } = useFormContext()
+  const section = useContext(InputGroupContext)
+
+  return <InputContainer {...register(section)} {...props} />
+}
+
+export const TextArea = (props) => {
+  const { register } = useFormContext()
+  const section = useContext(InputGroupContext)
+
+  return <TextAreaContainer {...register(section)} {...props} />
+}
+
+const InputContainer = styled.input`
+  width: 100%;
+  padding: 2rem 2.4rem;
+  border-radius: 0.8rem;
+  border: 0.1rem solid ${colors.grey[300]};
+  outline: none;
+  box-sizing: border-box;
+  font: inherit;
+  color: ${colors.grey[700]};
+  font-size: ${font.fontSize[500]};
+  line-height: ${font.lineHeight[500]};
+
+  &::placeholder {
+    color: ${colors.grey[500]};
+  }
+
+  &:focus {
+    outline: none;
+  }
+`
+
+const TextAreaContainer = styled.textarea`
+  width: 100%;
+  min-height: 18rem;
+  padding: 2rem 2.4rem;
+  border-radius: 0.8rem;
+  border: 0.1rem solid ${colors.grey[300]};
+  outline: none;
+  box-sizing: border-box;
+  font: inherit;
+  color: ${colors.grey[700]};
+  font-size: ${font.fontSize[500]};
+  line-height: ${font.lineHeight[500]};
+  resize: none;
+
+  &::placeholder {
+    color: ${colors.grey[500]};
+  }
+
+  &:focus {
+    outline: none;
+  }
+`

--- a/src/components/views/inputGroup/Label.jsx
+++ b/src/components/views/inputGroup/Label.jsx
@@ -1,0 +1,47 @@
+import { useContext } from 'react'
+import { useFormContext } from 'react-hook-form'
+import styled from 'styled-components'
+
+import { InputGroupContext } from '@/hooks/useInputGroupContext'
+import { font } from '@/styles/font'
+import { colors } from '@/styles/palette'
+
+export const Label = ({ successMessage, errorMessage, label }) => {
+  const {
+    formState: { errors },
+  } = useFormContext()
+  const section = useContext(InputGroupContext)
+  const currentErrorMessage = errors[section]?.message?.toString()
+
+  return (
+    <LabelContainer>
+      <LabelMessage>{label}</LabelMessage>
+      {currentErrorMessage ? (
+        <Message className="p-900 text-error">* {currentErrorMessage}</Message>
+      ) : (
+        <>
+          {successMessage && <Message $success>* {successMessage}</Message>}
+          {errorMessage && <Message>* {errorMessage}</Message>}
+        </>
+      )}
+    </LabelContainer>
+  )
+}
+
+const LabelContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+`
+
+const LabelMessage = styled.p`
+  font-size: ${font.fontSize[400]};
+  line-height: ${font.lineHeight[400]};
+  color: ${colors.blue[500]};
+`
+
+const Message = styled.p`
+  font-size: ${font.fontSize[500]};
+  line-height: ${font.lineHeight[500]};
+  color: ${({ $success }) => ($success ? colors.ect.success : colors.ect.error)};
+`

--- a/src/components/views/inputGroup/index.jsx
+++ b/src/components/views/inputGroup/index.jsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components'
+
+import { InputGroupContext } from '@/hooks/useInputGroupContext'
+
+import { Input } from './Input'
+import { TextArea } from './Input'
+import { Label } from './Label'
+
+const InputGroupProvider = ({ section, children }) => {
+  return (
+    <InputGroupContext.Provider value={section}>
+      <GroupSection>{children}</GroupSection>
+    </InputGroupContext.Provider>
+  )
+}
+
+export const InputGroup = Object.assign(InputGroupProvider, {
+  Input,
+  TextArea,
+  Label,
+})
+
+const GroupSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+`

--- a/src/hooks/useInputGroupContext.js
+++ b/src/hooks/useInputGroupContext.js
@@ -1,0 +1,13 @@
+import { createContext } from 'react'
+import { useContext } from 'react'
+
+export const InputGroupContext = createContext('')
+
+export const useInputGroupContext = () => {
+  const context = useContext(InputGroupContext)
+
+  if (!context) {
+    throw new Error('InputGroupContext.* 컴포넌트만 사용 가능합니다.')
+  }
+  return context
+}


### PR DESCRIPTION
## ❗️ 변경 사항

- InputGroup 컴포넌트 구현.
- 컴파운드 컴포넌트 패턴을 사용하여 Input, TextArea, Label을 묶어서 사용.
- section을 context로 관리하여 InputGroup 전체에서 사용할 수 있도록 함.

- 리렌더링 방지 및 유효성 검사의 편의를 위하여 react-hook-form, zod, resolvers 설치

close #11
